### PR TITLE
Use registry.opensuse.org by default

### DIFF
--- a/virtual-host-gatherer/Makefile
+++ b/virtual-host-gatherer/Makefile
@@ -1,6 +1,6 @@
 # Docker tests variables
 DOCKER_CONTAINER_NAME = systemsmanagement/uyuni/master/docker/containers/uyuni-master-gatherer
-DOCKER_REGISTRY       = ${DOCKER_REGISTRY}
+DOCKER_REGISTRY       = registry.opensuse.org
 DOCKER_RUN_EXPORT     = "PYTHONPATH=/gatherer/"
 DOCKER_VOLUMES        = -v "$(CURDIR)/:/gatherer"
 


### PR DESCRIPTION
If we have the image name by default, let's set the registry as well.

Users can always use different registries or images as needed, for example at our CI:
```
make DOCKER_REGISTRY="registry.suse.de" DOCKER_CONTAINER_NAME="devel/galaxy/manager/4.2/docker/containers/suma-4.2-gatherer" docker_pylint