### PR TITLE
Fix pylintrc init-hook to work with Python 3

### DIFF
--- a/virtual-host-gatherer/.pylintrc
+++ b/virtual-host-gatherer/.pylintrc
@@ -5,14 +5,16 @@
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
 init-hook="
-  exec 'aW1wb3J0IG9zLCBzeXMKCmlmICdWSVJUVUFMX0VOVicgaW4gb3MuZW52aXJvbjoKCiAgICB2ZV9k \
+  import base64
+  exec(base64.b64decode(
+  'aW1wb3J0IG9zLCBzeXMKCmlmICdWSVJUVUFMX0VOVicgaW4gb3MuZW52aXJvbjoKCiAgICB2ZV9k \
   aXIgPSBvcy5lbnZpcm9uWydWSVJUVUFMX0VOViddCiAgICB2ZV9kaXIgaW4gc3lzLnBhdGggb3Ig \
   c3lzLnBhdGguaW5zZXJ0KDAsIHZlX2RpcikKICAgIGFjdGl2YXRlX3RoaXMgPSBvcy5wYXRoLmpv \
   aW4ob3MucGF0aC5qb2luKHZlX2RpciwgJ2JpbicpLCAnYWN0aXZhdGVfdGhpcy5weScpCgogICAg \
   IyBGaXggZm9yIHdpbmRvd3MKICAgIGlmIG5vdCBvcy5wYXRoLmV4aXN0cyhhY3RpdmF0ZV90aGlz \
   KToKICAgICAgICBhY3RpdmF0ZV90aGlzID0gb3MucGF0aC5qb2luKG9zLnBhdGguam9pbih2ZV9k \
   aXIsICdTY3JpcHRzJyksICdhY3RpdmF0ZV90aGlzLnB5JykKCiAgICBleGVjZmlsZShhY3RpdmF0 \
-  ZV90aGlzLCBkaWN0KF9fZmlsZV9fPWFjdGl2YXRlX3RoaXMpKQo='.decode('base64')"
+  ZV90aGlzLCBkaWN0KF9fZmlsZV9fPWFjdGl2YXRlX3RoaXMpKQo='))"
 
 # Profiled execution.
 profile=no


### PR DESCRIPTION
This PR prevents `pylint` to crash when running with Python 3:

```
pylint --rcfile ./.pylintrc --output-format=parseable --reports=y lib/gatherer scripts/virtual-host-gatherer > reports/pylint.log
Using config file /gatherer/.pylintrc
Traceback (most recent call last):
  File "/usr/bin/pylint", line 11, in <module>
    load_entry_point('pylint==1.8.2', 'console_scripts', 'pylint')()
  File "/usr/lib/python3.6/site-packages/pylint/__init__.py", line 16, in run_pylint
    Run(sys.argv[1:])
  File "/usr/lib/python3.6/site-packages/pylint/lint.py", line 1307, in __init__
    'init-hook')))
  File "/usr/lib/python3.6/site-packages/pylint/lint.py", line 1408, in cb_init_hook
    exec(value) # pylint: disable=exec-used
  File "<string>", line 9
    ZV90aGlzLCBkaWN0KF9fZmlsZV9fPWFjdGl2YXRlX3RoaXMpKQo='.decode('base64')
                                                        ^
SyntaxError: invalid syntax
```

After this PR, `pylint` is able to run although it is currently reporting pylint issues.