### PR TITLE
Display pylint results also in stdout output

### DIFF
--- a/virtual-host-gatherer/Makefile
+++ b/virtual-host-gatherer/Makefile
@@ -11,13 +11,13 @@ pylint ::
 	pylint --rcfile ./.pylintrc lib/gatherer scripts/virtual-host-gatherer
 
 pylint_in_docker ::
-	pylint --rcfile ./.pylintrc --output-format=parseable --reports=y lib/gatherer scripts/virtual-host-gatherer > reports/pylint.log
+	pylint --rcfile ./.pylintrc --output-format=parseable --reports=y lib/gatherer scripts/virtual-host-gatherer | tee reports/pylint.log && exit $${PIPESTATUS[0]}
 
 py3k ::
 	pylint --py3k --rcfile ./.pylintrc lib/gatherer scripts/virtual-host-gatherer
 
 py3k_in_docker ::
-	pylint --py3k --rcfile ./.pylintrc --output-format=parseable --reports=y lib/gatherer scripts/virtual-host-gathererr > reports/py3k.log
+	pylint --py3k --rcfile ./.pylintrc --output-format=parseable --reports=y lib/gatherer scripts/virtual-host-gatherer | tee reports/py3k.log && exit $${PIPESTATUS[0]}
 
 docker_pylint :: pull_container
 	docker run --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_CONTAINER_NAME) /bin/sh -c "cd /gatherer && make pylint_in_docker && make py3k_in_docker"


### PR DESCRIPTION
This PR makes the pylint tests results to be also displayed in the stdout when running `make docker_pylint`.

This way, you can easily see the results in the CI job.