### PR TITLE
Fix pylintrc to work with latest pylint versions

### DIFF
--- a/virtual-host-gatherer/.pylintrc
+++ b/virtual-host-gatherer/.pylintrc
@@ -13,8 +13,9 @@ init-hook="
   aW4ob3MucGF0aC5qb2luKHZlX2RpciwgJ2JpbicpLCAnYWN0aXZhdGVfdGhpcy5weScpCgogICAg \
   IyBGaXggZm9yIHdpbmRvd3MKICAgIGlmIG5vdCBvcy5wYXRoLmV4aXN0cyhhY3RpdmF0ZV90aGlz \
   KToKICAgICAgICBhY3RpdmF0ZV90aGlzID0gb3MucGF0aC5qb2luKG9zLnBhdGguam9pbih2ZV9k \
-  aXIsICdTY3JpcHRzJyksICdhY3RpdmF0ZV90aGlzLnB5JykKCiAgICBleGVjZmlsZShhY3RpdmF0 \
-  ZV90aGlzLCBkaWN0KF9fZmlsZV9fPWFjdGl2YXRlX3RoaXMpKQo='))"
+  aXIsICdTY3JpcHRzJyksICdhY3RpdmF0ZV90aGlzLnB5JykKCiAgICBleGVjKGNvbXBpbGUob3Bl \
+  bihhY3RpdmF0ZV90aGlzLCAncmInKS5yZWFkKCksIGFjdGl2YXRlX3RoaXMsICdleGVjJyksIGRp \
+  Y3QoX19maWxlX189YWN0aXZhdGVfdGhpcykpCg=='))"
 
 # Profiled execution.
 profile=no


### PR DESCRIPTION
The init-hook script that is currently specified in the .pylintrc
file uses execfile() which is a Python 2-ism that has been dropped
in Python 3, and backwards compatibility support for it has been
dropped in the latest versions of pylint itself.

Some research shows that the exec() based pattern:

    exec(compile(open(script).read(), script, 'exec'), ...)

is equivalent to the existing execfile() pattern:

    execfile(script, ...)

and is also compatible with older and newer versions of pylint.

This change updates the init-hook script to use the new exec() based
pattern, allowing the .pylintrc script to work with older and newer
versions of pylint.

Fixes #21