### PR TITLE
Enable Gatherer reuse in other projects

### DIFF
--- a/virtual-host-gatherer/lib/gatherer/gatherer.py
+++ b/virtual-host-gatherer/lib/gatherer/gatherer.py
@@ -70,16 +70,35 @@ class Gatherer(object):
     Gatherer class.
     """
 
-    def __init__(self, opts):
+    def __init__(self, opts=None):
         """
         Constructor.
 
-        :param opts: Command line options.
+        :param opts: Command line options (optional).
         :return:
         """
 
+        # Define a minimal opts if not provided.
+        if opts is None:
+            opts = argparse.Namespace(verbose=0, infile='-')
         self.options = opts
+
         self.log = logging.getLogger('')
+
+        # Should be skipped when no opts was provided.
+        if 'logfile' in self.options:
+            self._setup_logging()
+
+        self.modules = dict()
+
+    def _setup_logging(self):
+        """
+        Setup logging for use as a command line tool.
+
+        Note that self.options.logfile must exist to call this method.
+
+        :return: void
+        """
         self.log.setLevel(logging.WARNING)
 
         stream_handler = logging.StreamHandler(sys.stderr)
@@ -89,8 +108,6 @@ class Gatherer(object):
         file_handler = RotatingFileHandler(self.options.logfile, maxBytes=(0x100000 * 5), backupCount=5)
         file_handler.setFormatter(logging.Formatter("%(asctime)s %(name)s - %(levelname)s: %(message)s"))
         self.log.addHandler(file_handler)
-
-        self.modules = dict()
 
     def list_modules(self):
         """


### PR DESCRIPTION
This patch makes the following changes:
  * make the opts argument optional, defining a sensible default if not
    specified
  * make the setup of logging conditional on the existence of a logfile
    entry in the opts

This minimal set of changes allows the virtual-host-gather project to be
leveraged in other projects, without side-effects, using this pattern:
  * Instantiate the Gatherer() with no arguments, e.g.
```
    g = Gatherer()
```
  * Call the list_modules() method to populate the modules mapping, e.g.
```
    module_params = g.list_modules()
```
  * Access specific worker instances via the modules attribute, e.g.
```
    vmware_worker = g.modules.get('VMware')
```

Closes: #28