### PR TITLE
Calculate cpu total values

### DIFF
--- a/virtual-host-gatherer/lib/gatherer/modules/Libvirt.py
+++ b/virtual-host-gatherer/lib/gatherer/modules/Libvirt.py
@@ -222,13 +222,16 @@ class Libvirt(WorkerInterface):
             hypervisor_hostname = conn.getHostname()
             host_capabilities_xml = self.get_host_capabilities(conn)
             host_cpu_topology = self.get_host_cpu_topology(host_capabilities_xml)
+            totalCpuSockets = int(host_cpu_topology.get('sockets'), 1)
+            totalCpuCores = int(host_cpu_topology.get('cores'), 1) * totalSockets
+            totalCpuThreads = int(host_cpu_topology.get('threads'), 1) * totalCores
             output[hypervisor_hostname] = {
                 'name': hypervisor_hostname,
                 'hostIdentifier': host_capabilities_xml.find('host/uuid').text,
                 'type': conn.getType(),
-                'totalCpuSockets': int(host_cpu_topology.get('sockets'), 0),
-                'totalCpuCores': int(host_cpu_topology.get('cores'), 0),
-                'totalCpuThreads': int(host_cpu_topology.get('threads'), 0),
+                'totalCpuSockets': totalCpuSockets,
+                'totalCpuCores': totalCpuCores,
+                'totalCpuThreads': totalCpuThreads,
                 'cpuVendor': host_capabilities_xml.find('host/cpu/vendor').text,
                 'cpuDescription': host_capabilities_xml.find('host/cpu/model').text,
                 'cpuArch': host_capabilities_xml.find('host/cpu/arch').text,

--- a/virtual-host-gatherer/virtual-host-gatherer.changes
+++ b/virtual-host-gatherer/virtual-host-gatherer.changes
@@ -1,3 +1,5 @@
+- Report total CPU numbers in the libvirt module
+
 -------------------------------------------------------------------
 Mon Nov 14 11:59:45 CET 2022 - Alexander Graul <agraul@suse.com>
 


### PR DESCRIPTION
Virtual host gather should return the total numbers of the CPU values.
As libvirt return sockets, cores per socket and threads per cores like:
```
      sockets: 2
      cores: 8
      threads: 2
```
we need to calculate the total numbers to get the correct output:
```
      sockets: 2
      cores: 16
      threads: 32
```