### PR TITLE
Fix host identifier for VMWare

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@ bak/
 data/
 virtual-host-gatherer/reports/
 .idea/
-
+build/

--- a/virtual-host-gatherer/lib/gatherer/modules/VMware.py
+++ b/virtual-host-gatherer/lib/gatherer/modules/VMware.py
@@ -118,6 +118,13 @@ class VMware(WorkerInterface):
                 mhz = (float(host.hardware.cpuInfo.hz) / float(1000 * 1000))
                 ram = (int(host.hardware.memorySize / (1024 * 1024)))
 
+                self.log.debug("Host identification for {0} -> UUID: {1} Vendor: {2} Serial Number: {3}".format(
+                    str(host),
+                    host.hardware.systemInfo.uuid,
+                    host.hardware.systemInfo.vendor,
+                    host.hardware.systemInfo.serialNumber
+                ))
+
                 output[host_name] = {
                     'type': 'vmware',
                     'name': host_name,

--- a/virtual-host-gatherer/lib/gatherer/modules/VMware.py
+++ b/virtual-host-gatherer/lib/gatherer/modules/VMware.py
@@ -117,10 +117,12 @@ class VMware(WorkerInterface):
                 host_name = host.summary.config.name.split()[0]
                 mhz = (float(host.hardware.cpuInfo.hz) / float(1000 * 1000))
                 ram = (int(host.hardware.memorySize / (1024 * 1024)))
+
                 output[host_name] = {
                     'type': 'vmware',
                     'name': host_name,
-                    'hostIdentifier': str(host),
+                    'hostIdentifier': host.hardware.systemInfo.uuid,
+                    'fallbackHostIdentifier': str(host),
                     'os': host.summary.config.product.name,
                     'osVersion': host.summary.config.product.version,
                     'totalCpuSockets': host.hardware.cpuInfo.numCpuPackages,
@@ -134,6 +136,7 @@ class VMware(WorkerInterface):
                     'vms': {},
                     'optionalVmData': {}
                 }
+
                 # If an additional hardware info is wanted:
                 # print "pciDevice: %s" % host.hardware.pciDevice
                 for virtual_machine in host.vm:

--- a/virtual-host-gatherer/virtual-host-gatherer.changes.mackdk.fix-host-identifier
+++ b/virtual-host-gatherer/virtual-host-gatherer.changes.mackdk.fix-host-identifier
@@ -1,0 +1,2 @@
+- Use uuid as host indentifier for VMWare hosted machines 
+  (bsc#1218724)


### PR DESCRIPTION
This PR changes the host identifier used when gathering data for VMWare machines. Currently the code is just calling `str(host)` which is not reliable after a major update of the VMWare software as reported in https://github.com/SUSE/spacewalk/issues/23401

This PR uses the field `uuid` and provides a new field `fallbackHostIdentifier` with the previous value to allow uyuni to match and update the value in the database.