### PR TITLE
Fix issue building package on Python 3.13

### DIFF
--- a/virtual-host-gatherer/virtual-host-gatherer.changes.meaksh.master-fix-issues-leap16
+++ b/virtual-host-gatherer/virtual-host-gatherer.changes.meaksh.master-fix-issues-leap16
@@ -1,0 +1,1 @@
+- Fix issue building package on Python 3.13

--- a/virtual-host-gatherer/virtual-host-gatherer.spec
+++ b/virtual-host-gatherer/virtual-host-gatherer.spec
@@ -43,6 +43,7 @@ BuildRequires:  libxslt-tools
 %endif
 BuildRequires:  %{python_module devel}
 BuildRequires:  %{python_module pycurl}
+BuildRequires:  %{python_module setuptools}
 BuildRequires:  %{python_module six}
 Requires:       %{python_module pycurl}
 Requires:       %{python_module six}


### PR DESCRIPTION
As `distutils` is not longer on Python 3.12+, we should use `setuptools` in order to build the package on recent Python versions.

